### PR TITLE
Fixed param bug in Canvas.js

### DIFF
--- a/Routes/Canvas.js
+++ b/Routes/Canvas.js
@@ -811,7 +811,7 @@ router.get('/gun', async (req, res) => {
 router.get('/fakequote', async (req, res) => {
 	const imgURL = req.query.imgUrl;
 	const text = req.query.text;
-	const username = req.query.text;
+	const username = req.query.username;
 	const roleColour = req.query.roleColour || '#ffffff';
 	let bot = false;
 


### PR DESCRIPTION
I'm so dumb sometimes lol, but I swear I made it req.query.username.
Very sus
I dunno why that happened :sweat_smile: 